### PR TITLE
Fix SHA-256 Certificate Check

### DIFF
--- a/src/playIntegrity.js
+++ b/src/playIntegrity.js
@@ -180,7 +180,7 @@ export async function verifyPlayIntegrity(
     if (
       appIntegrity?.certificateSha256Digest == null ||
       appIntegrity.certificateSha256Digest.some((e) =>
-        validCertificateSha256Digest.includes(e)
+        !validCertificateSha256Digest.includes(e)
       )
     ) {
       if (errorAndExit(res, `Invalid certificateSha256Digest`)) return false;


### PR DESCRIPTION
I think this is right - the check seemed to be the wrong way round so if a valid digest was specified then it would fail the check